### PR TITLE
feat: remove ssl_certificates from load balancer 

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ No modules.
 | [google_compute_global_forwarding_rule.fwd_ipv4_https](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_forwarding_rule) | resource |
 | [google_compute_global_forwarding_rule.fwd_ipv6](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_forwarding_rule) | resource |
 | [google_compute_global_forwarding_rule.fwd_ipv6_https](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_forwarding_rule) | resource |
-| [google_compute_managed_ssl_certificate.gtmss_ssl_cert](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_managed_ssl_certificate) | resource |
 | [google_compute_region_network_endpoint_group.serverless-neg](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_network_endpoint_group) | resource |
 | [google_compute_target_http_proxy.l7_proxy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_target_http_proxy) | resource |
 | [google_compute_url_map.gtmss_url_map](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_url_map) | resource |

--- a/load_balancer.tf
+++ b/load_balancer.tf
@@ -111,13 +111,12 @@ resource "google_compute_target_http_proxy" "l7_proxy" {
 }
 
 resource "google_compute_target_https_proxy" "l7_proxy" {
-  count            = var.deploy_load_balancer && var.deploy_ssl ? 1 : 0
-  provider         = google-beta
-  project          = var.project_id
-  name             = "l7-xlb-gtmss-proxy-https"
-  url_map          = google_compute_url_map.gtmss_url_map.0.id
-  ssl_certificates = values(google_compute_managed_ssl_certificate.gtmss_ssl_cert)[*].self_link
-  certificate_map  = "//certificatemanager.googleapis.com/${google_certificate_manager_certificate_map.sgtm_certmap.id}"
+  count           = var.deploy_load_balancer && var.deploy_ssl ? 1 : 0
+  provider        = google-beta
+  project         = var.project_id
+  name            = "l7-xlb-gtmss-proxy-https"
+  url_map         = google_compute_url_map.gtmss_url_map.0.id
+  certificate_map = "//certificatemanager.googleapis.com/${google_certificate_manager_certificate_map.sgtm_certmap.id}"
 }
 
 resource "google_compute_backend_service" "gtmss_backend" {
@@ -139,15 +138,6 @@ resource "google_compute_url_map" "gtmss_url_map" {
   count           = var.deploy_load_balancer ? 1 : 0
   name            = "gtmss-url-map"
   default_service = google_compute_backend_service.gtmss_backend.0.id
-}
-
-
-resource "google_compute_managed_ssl_certificate" "gtmss_ssl_cert" {
-  for_each = (var.deploy_load_balancer && var.deploy_ssl ? toset(var.domains) : [])
-  name     = "gtmss-ssl-cert-${replace(each.key, ".", "-")}"
-  managed {
-    domains = [each.key]
-  }
 }
 
 resource "google_certificate_manager_certificate" "sgtm_ssl_cert" {


### PR DESCRIPTION
This version removes SSL certificates n favour of certificate maps. 

If you have previously deployed this module, ensure you upgrade to v0.3.0 before upgrading to v0.4.0. This is because you have to attach the certificate map and the certificates need to authorise before the old SSL certificates can be removed. 