### PR TITLE
feat: SSL Policy Creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ No modules.
 | [google_compute_global_forwarding_rule.fwd_ipv6](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_forwarding_rule) | resource |
 | [google_compute_global_forwarding_rule.fwd_ipv6_https](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_forwarding_rule) | resource |
 | [google_compute_region_network_endpoint_group.serverless-neg](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_network_endpoint_group) | resource |
+| [google_compute_ssl_policy.sgtm-ssl-policy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_ssl_policy) | resource |
 | [google_compute_target_http_proxy.l7_proxy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_target_http_proxy) | resource |
 | [google_compute_url_map.gtmss_url_map](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_url_map) | resource |
 | [google_project_service.certificate-manager-api](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
@@ -76,14 +77,17 @@ No modules.
 | <a name="input_deploy_load_balancer"></a> [deploy\_load\_balancer](#input\_deploy\_load\_balancer) | Whether to deploy a load balancer in front of the sGTM instances | `bool` | `false` | no |
 | <a name="input_deploy_preview_server"></a> [deploy\_preview\_server](#input\_deploy\_preview\_server) | Whether to deploy an sGTM Preview Server | `bool` | `false` | no |
 | <a name="input_deploy_ssl"></a> [deploy\_ssl](#input\_deploy\_ssl) | Whether to deploy an SSL certificate for the sGTM instances. If you select this, you need to set the domain(s) in the domains variable. | `bool` | `false` | no |
+| <a name="input_deploy_ssl_policy"></a> [deploy\_ssl\_policy](#input\_deploy\_ssl\_policy) | Whether to deploy an SSL policy for the sGTM instances | `bool` | `false` | no |
 | <a name="input_domains"></a> [domains](#input\_domains) | The domains to deploy the sGTM instances on. These are used to provision the certificates, so should end with a full stop e.g. `gtm.example.com.` | `list(string)` | `[]` | no |
 | <a name="input_max_instance_count"></a> [max\_instance\_count](#input\_max\_instance\_count) | The maximum number of instances that each region can scale to | `number` | `10` | no |
 | <a name="input_max_preview_instance_count"></a> [max\_preview\_instance\_count](#input\_max\_preview\_instance\_count) | The maximum number of sGTM Preview Servers to deploy | `number` | `1` | no |
 | <a name="input_min_instance_count"></a> [min\_instance\_count](#input\_min\_instance\_count) | The minimum number of instances that each region can scale to | `number` | `1` | no |
 | <a name="input_min_preview_instance_count"></a> [min\_preview\_instance\_count](#input\_min\_preview\_instance\_count) | The minimum number of sGTM Preview Servers to deploy | `number` | `1` | no |
+| <a name="input_min_tls_version"></a> [min\_tls\_version](#input\_min\_tls\_version) | The minimum TLS version for the sGTM instances | `string` | `"TLS_1_2"` | no |
 | <a name="input_preview_region"></a> [preview\_region](#input\_preview\_region) | The region to deploy the sGTM Preview Server | `string` | `"europe-west1"` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The Google Cloud Project ID that sGTM will be deployed in | `string` | n/a | yes |
 | <a name="input_regions"></a> [regions](#input\_regions) | The Google Cloud Regions that sGTM will be deployed in | `list(string)` | <pre>[<br>  "europe-west1"<br>]</pre> | no |
+| <a name="input_ssl_policy_profile"></a> [ssl\_policy\_profile](#input\_ssl\_policy\_profile) | The SSL policy profile for the sGTM instances | `string` | `"MODERN"` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -73,12 +73,17 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_cdn_settings"></a> [cdn\_settings](#input\_cdn\_settings) | The settings for the CDN policy | <pre>object({<br>    cache_mode  = string<br>    default_ttl = number<br>    client_ttl  = number<br>    max_ttl     = number<br>    cache_key_policy = object({<br>      include_host           = bool<br>      include_protocol       = bool<br>      include_query_string   = bool,<br>      whitelist_query_string = list(string),<br>      blacklist_query_string = list(string),<br>    })<br>  })</pre> | <pre>{<br>  "cache_key_policy": {<br>    "blacklist_query_string": [],<br>    "include_host": true,<br>    "include_protocol": true,<br>    "include_query_string": true,<br>    "whitelist_query_string": []<br>  },<br>  "cache_mode": "FORCE_CACHE_ALL",<br>  "client_ttl": 3600,<br>  "default_ttl": 3600,<br>  "max_ttl": null<br>}</pre> | no |
+| <a name="input_cloud_armor_policy"></a> [cloud\_armor\_policy](#input\_cloud\_armor\_policy) | The Cloud Armor policy to apply to the sGTM instances. This should be the self\_link attribute for your policy. | `string` | `null` | no |
 | <a name="input_container_config"></a> [container\_config](#input\_container\_config) | The container configuration for your sGTM | `string` | n/a | yes |
+| <a name="input_custom_response_headers"></a> [custom\_response\_headers](#input\_custom\_response\_headers) | Custom response headers to add to the backend service | `list(string)` | `[]` | no |
+| <a name="input_deploy_cdn"></a> [deploy\_cdn](#input\_deploy\_cdn) | Whether to deploy a CDN policy for the sGTM instances | `bool` | `false` | no |
 | <a name="input_deploy_load_balancer"></a> [deploy\_load\_balancer](#input\_deploy\_load\_balancer) | Whether to deploy a load balancer in front of the sGTM instances | `bool` | `false` | no |
 | <a name="input_deploy_preview_server"></a> [deploy\_preview\_server](#input\_deploy\_preview\_server) | Whether to deploy an sGTM Preview Server | `bool` | `false` | no |
 | <a name="input_deploy_ssl"></a> [deploy\_ssl](#input\_deploy\_ssl) | Whether to deploy an SSL certificate for the sGTM instances. If you select this, you need to set the domain(s) in the domains variable. | `bool` | `false` | no |
 | <a name="input_deploy_ssl_policy"></a> [deploy\_ssl\_policy](#input\_deploy\_ssl\_policy) | Whether to deploy an SSL policy for the sGTM instances | `bool` | `false` | no |
 | <a name="input_domains"></a> [domains](#input\_domains) | The domains to deploy the sGTM instances on. These are used to provision the certificates, so should end with a full stop e.g. `gtm.example.com.` | `list(string)` | `[]` | no |
+| <a name="input_enable_logging"></a> [enable\_logging](#input\_enable\_logging) | Whether to enable logging for the sGTM instances | `bool` | `false` | no |
 | <a name="input_max_instance_count"></a> [max\_instance\_count](#input\_max\_instance\_count) | The maximum number of instances that each region can scale to | `number` | `10` | no |
 | <a name="input_max_preview_instance_count"></a> [max\_preview\_instance\_count](#input\_max\_preview\_instance\_count) | The maximum number of sGTM Preview Servers to deploy | `number` | `1` | no |
 | <a name="input_min_instance_count"></a> [min\_instance\_count](#input\_min\_instance\_count) | The minimum number of instances that each region can scale to | `number` | `1` | no |
@@ -87,6 +92,7 @@ No modules.
 | <a name="input_preview_region"></a> [preview\_region](#input\_preview\_region) | The region to deploy the sGTM Preview Server | `string` | `"europe-west1"` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The Google Cloud Project ID that sGTM will be deployed in | `string` | n/a | yes |
 | <a name="input_regions"></a> [regions](#input\_regions) | The Google Cloud Regions that sGTM will be deployed in | `list(string)` | <pre>[<br>  "europe-west1"<br>]</pre> | no |
+| <a name="input_sample_rate"></a> [sample\_rate](#input\_sample\_rate) | The rate at which to log requests | `number` | `0.1` | no |
 | <a name="input_ssl_policy_profile"></a> [ssl\_policy\_profile](#input\_ssl\_policy\_profile) | The SSL policy profile for the sGTM instances | `string` | `"MODERN"` | no |
 
 ## Outputs

--- a/certificates.tf
+++ b/certificates.tf
@@ -1,0 +1,27 @@
+resource "google_certificate_manager_certificate" "sgtm_ssl_cert" {
+  for_each = (var.deploy_load_balancer && var.deploy_ssl ? toset(var.domains) : [])
+  name     = "sgtm-ssl-cert-${replace(each.key, ".", "-")}"
+  managed {
+    domains = [each.key]
+  }
+}
+
+resource "random_id" "tf_prefix" {
+  byte_length = 8
+}
+
+resource "google_certificate_manager_certificate_map" "sgtm_certmap" {
+  count       = var.deploy_load_balancer && var.deploy_ssl ? 1 : 0
+  depends_on  = [google_project_service.certificate-manager-api]
+  name        = "sgtm-certmap-${random_id.tf_prefix.hex}"
+  description = "Server Side GTM certificate map"
+}
+
+resource "google_certificate_manager_certificate_map_entry" "certmap_entries" {
+  for_each     = (var.deploy_load_balancer && var.deploy_ssl ? toset(var.domains) : [])
+  name         = "sgtm-entry-${replace(each.key, ".", "-")}"
+  description  = "Certificate map entry for ${each.key}"
+  map          = google_certificate_manager_certificate_map.sgtm_certmap.0.name
+  certificates = [google_certificate_manager_certificate.sgtm_ssl_cert[each.key].id]
+  hostname     = each.key
+}

--- a/cloud_run.tf
+++ b/cloud_run.tf
@@ -26,6 +26,10 @@ resource "google_cloud_run_v2_service" "gtmss-cr" {
         name  = "CONTAINER_CONFIG"
         value = var.container_config
       }
+      env {
+        name  = "PREVIEW_SERVER_URL"
+        value = var.deploy_preview_server ? google_cloud_run_v2_service.gtmss-cr-preview[0].uri : ""
+      }
     }
   }
 }

--- a/load_balancer.tf
+++ b/load_balancer.tf
@@ -117,7 +117,7 @@ resource "google_compute_target_https_proxy" "l7_proxy" {
   name            = "l7-xlb-gtmss-proxy-https"
   url_map         = google_compute_url_map.gtmss_url_map.0.id
   certificate_map = "//certificatemanager.googleapis.com/${google_certificate_manager_certificate_map.sgtm_certmap.0.id}"
-  ssl_policy      = var.deploy_ssl_policy ? "projects/${var.project_id}/global/sslPolicies/${google_compute_ssl_policy.sgtm-ssl-policy.0.id}" : null
+  ssl_policy      = var.deploy_ssl_policy ? google_compute_ssl_policy.sgtm-ssl-policy.0.self_link : null
 }
 
 resource "google_compute_backend_service" "gtmss_backend" {

--- a/load_balancer.tf
+++ b/load_balancer.tf
@@ -116,7 +116,8 @@ resource "google_compute_target_https_proxy" "l7_proxy" {
   project         = var.project_id
   name            = "l7-xlb-gtmss-proxy-https"
   url_map         = google_compute_url_map.gtmss_url_map.0.id
-  certificate_map = "//certificatemanager.googleapis.com/${google_certificate_manager_certificate_map.sgtm_certmap.id}"
+  certificate_map = "//certificatemanager.googleapis.com/${google_certificate_manager_certificate_map.sgtm_certmap.0.id}"
+  ssl_policy      = var.deploy_ssl_policy ? "projects/${var.project_id}/global/sslPolicies/${google_compute_ssl_policy.sgtm-ssl-policy.0.id}" : null
 }
 
 resource "google_compute_backend_service" "gtmss_backend" {
@@ -138,4 +139,11 @@ resource "google_compute_url_map" "gtmss_url_map" {
   count           = var.deploy_load_balancer ? 1 : 0
   name            = "gtmss-url-map"
   default_service = google_compute_backend_service.gtmss_backend.0.id
+}
+
+resource "google_compute_ssl_policy" "sgtm-ssl-policy" {
+  count           = var.deploy_ssl_policy ? 1 : 0
+  name            = "sgtm-ssl-policy-${random_id.tf_prefix.hex}"
+  profile         = var.ssl_policy_profile
+  min_tls_version = var.min_tls_version
 }

--- a/load_balancer.tf
+++ b/load_balancer.tf
@@ -139,30 +139,3 @@ resource "google_compute_url_map" "gtmss_url_map" {
   name            = "gtmss-url-map"
   default_service = google_compute_backend_service.gtmss_backend.0.id
 }
-
-resource "google_certificate_manager_certificate" "sgtm_ssl_cert" {
-  for_each = (var.deploy_load_balancer && var.deploy_ssl ? toset(var.domains) : [])
-  name     = "sgtm-ssl-cert-${replace(each.key, ".", "-")}"
-  managed {
-    domains = [each.key]
-  }
-}
-#
-resource "random_id" "tf_prefix" {
-  byte_length = 8
-}
-
-resource "google_certificate_manager_certificate_map" "sgtm_certmap" {
-  depends_on  = [google_project_service.certificate-manager-api]
-  name        = "sgtm-certmap-${random_id.tf_prefix.hex}"
-  description = "Server Side GTM certificate map"
-}
-
-resource "google_certificate_manager_certificate_map_entry" "certmap_entries" {
-  for_each     = (var.deploy_load_balancer && var.deploy_ssl ? toset(var.domains) : [])
-  name         = "sgtm-entry-${replace(each.key, ".", "-")}"
-  description  = "Certificate map entry for ${each.key}"
-  map          = google_certificate_manager_certificate_map.sgtm_certmap.name
-  certificates = [google_certificate_manager_certificate.sgtm_ssl_cert[each.key].id]
-  hostname     = each.key
-}

--- a/variables.tf
+++ b/variables.tf
@@ -67,3 +67,20 @@ variable "domains" {
   type        = list(string)
   default     = []
 }
+
+variable "deploy_ssl_policy" {
+  description = "Whether to deploy an SSL policy for the sGTM instances"
+  type        = bool
+  default     = false
+}
+
+variable "ssl_policy_profile" {
+  description = "The SSL policy profile for the sGTM instances"
+  type        = string
+  default     = "MODERN"
+}
+variable "min_tls_version" {
+  description = "The minimum TLS version for the sGTM instances"
+  type        = string
+  default     = "TLS_1_2"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -79,8 +79,73 @@ variable "ssl_policy_profile" {
   type        = string
   default     = "MODERN"
 }
+
 variable "min_tls_version" {
   description = "The minimum TLS version for the sGTM instances"
   type        = string
   default     = "TLS_1_2"
+}
+
+variable "cloud_armor_policy" {
+  description = "The Cloud Armor policy to apply to the sGTM instances. This should be the self_link attribute for your policy."
+  type        = string
+  default     = null
+}
+
+variable "enable_logging" {
+  description = "Whether to enable logging for the sGTM instances"
+  type        = bool
+  default     = false
+}
+
+variable "sample_rate" {
+  description = "The rate at which to log requests"
+  type        = number
+  default     = 0.1
+  validation {
+    condition     = var.sample_rate >= 0 && var.sample_rate <= 1
+    error_message = "sample_rate must be between 0 and 1"
+  }
+}
+
+variable "deploy_cdn" {
+  description = "Whether to deploy a CDN policy for the sGTM instances"
+  type        = bool
+  default     = false
+}
+
+variable "cdn_settings" {
+  description = "The settings for the CDN policy"
+  type = object({
+    cache_mode  = string
+    default_ttl = number
+    client_ttl  = number
+    max_ttl     = number
+    cache_key_policy = object({
+      include_host           = bool
+      include_protocol       = bool
+      include_query_string   = bool,
+      whitelist_query_string = list(string),
+      blacklist_query_string = list(string),
+    })
+  })
+  default = {
+    cache_mode  = "FORCE_CACHE_ALL"
+    default_ttl = 3600
+    client_ttl  = 3600
+    max_ttl     = null
+    cache_key_policy = {
+      include_host           = true
+      include_protocol       = true
+      include_query_string   = true
+      whitelist_query_string = []
+      blacklist_query_string = []
+    }
+  }
+}
+
+variable "custom_response_headers" {
+  description = "Custom response headers to add to the backend service"
+  type        = list(string)
+  default     = []
 }


### PR DESCRIPTION
This update enables a bespoke SSL policy to be deployed onto the load balancer. This will mainly be required in instances where security require a minimum TLS for compliance.